### PR TITLE
site-header overflow: visible

### DIFF
--- a/southside/static/css/southside.css
+++ b/southside/static/css/southside.css
@@ -2,3 +2,7 @@
     text-align: center;
     text-transform: uppercase;
 }
+
+.site-header {
+    overflow: visible;
+}


### PR DESCRIPTION
before

![before](https://user-images.githubusercontent.com/1151759/40256988-73a8b854-5aba-11e8-81d2-9190a854116a.png)

after

![after](https://user-images.githubusercontent.com/1151759/40256993-775aaa70-5aba-11e8-8e87-f493a496e402.png)