### PR TITLE
crosslink case files and character pages, use appearances taxonomy

### DIFF
--- a/southside/content/characters/hanamir.md
+++ b/southside/content/characters/hanamir.md
@@ -5,6 +5,12 @@
     "race": "Half-Orc"
 }
 
+# Case Files
+
+Hanamir is conducting an [investigation on crimes affecting the property of the Drephis State University
+Inter-Library-Loan system (DSU ILL)](/hanamir-case-files).
+
+
 # Backstory
 
 An orphaned half-orc, Hanamir was adopted in childhood by a small regional monastic college, part of the Drephis State University system.

--- a/southside/content/hanamir-case-files/843-11-06.md
+++ b/southside/content/hanamir-case-files/843-11-06.md
@@ -1,8 +1,21 @@
 {
-    "title": "Case File 843-11-06",
+    "appearances": [
+        "the-savage",
+        "khargol",
+        "hermione",
+        "buddy",
+        "pouru",
+        "harlan",
+        "slee",
+        "redyl",
+        "kandir",
+        "cazna"
+    ],
+    "appearances_weight": 8431106,
     "description": "Organization A, its potential connections, 'the Lich', and available investigative avenues",
+    "location": "Seaside, near main pyramid, Ruins of Ixquichpehua",
     "timestamp": "843-11-06",
-    "location": "Seaside, near main pyramid, Ruins of Ixquichpehua"
+    "title": "Case File 843-11-06"
 }
 
 *Written after the [mission to the Ruins of Ixquichpehua](/chapters/so-long-for-now)*
@@ -17,7 +30,7 @@ The trail of clues in the Book Crime investigation has seemingly gone cold. Let 
 `Organization A` is known to have:
 
 * broken into the City of the Dead
-* captured spellcasters, including Redyl and Hermione
+* captured spellcasters, including [Redyl](/characters/redyl/) and [Hermione](/characters/hermione/)
 
 ## Potential Connections
 
@@ -28,12 +41,12 @@ If Khargol and Redyl's testimony is reliable (it fits with the [physical evidenc
 An anti-divine message seems to resonate with the [teachings of the Messenger](/chapters/rockabout/); therefore, the Messenger's Cult and `organization A` may be identical.
 
 ### The Anti-Magic League
-The [Anti-Magic League](/chapters/neophytes-big-city)'s activities may be related to the Messenger's Cult, as well as Ultas Kandir. The disappearances tied to the Northern Shipments served as political cover for the passage of the anti-magic-item laws advocated by the League.
+The [Anti-Magic League](/chapters/neophytes-big-city)'s activities may be related to the Messenger's Cult, as well as Ultas [Kandir](/characters/kandir/). The disappearances tied to the Northern Shipments served as political cover for the passage of the anti-magic-item laws advocated by the League.
 
 ### Minister Ultas Kandir
 The Minister of Trade's attempt to [deflect the king's attention from the Lich](/chapters/neophytes-big-city/) is troubling. As well, he seems to have been the key figure in the recent successes of the Anti-Magic League.
 
-### General Nai Pouru
+### General Nai [Pouru](/characters/pouru/)
 General Pouru was the key figure in [arranging the Northern Shipments](chapters/law-and-order-special-dictums-unit), but her affect during her trial was strange, and suggests that she may have been acting under duress. Can anything more be learned from her?
 
 * What was the purpose of transporting prisoners to the Northern Ruins?
@@ -41,14 +54,14 @@ General Pouru was the key figure in [arranging the Northern Shipments](chapters/
 * What happened to the prisoners?
 
 # "The Lich"
-Harlan was sent a [dream of dethroning Kord](/chapters/zombie-zombie-zombie-ie-ie/), another anti-divine message. Assuming that the sender of these dreams was the Lich, one could assume that `organization A` is also connected to the Lich. This is, however, a tenuous connection - the other dreams had no similar anti-divine content).
+[Harlan](/characters/harlan/) was sent a [dream of dethroning Kord](/chapters/zombie-zombie-zombie-ie-ie/), another anti-divine message. Assuming that the sender of these dreams was the Lich, one could assume that `organization A` is also connected to the Lich. This is, however, a tenuous connection - the other dreams had no similar anti-divine content).
 
 Indeed, assuming that Khargol's purpose in entering the City of the Dead was to enlist the Lich's aid for `organization A`, his immediate killing suggests that, at least, there is some separation between `organization A` and the Lich. If `organization A` was controlled by the Lich, why would Khargol need to seek an audience with him?
 
-It's possible that the Lich's power does not yet extend far beyond the City (though far enough to ensorcle the Savage, outside the seal, and send us dreams after we had entered the City). We have no evidence yet of any other Lich-controlled activity.
+It's possible that the Lich's power does not yet extend far beyond the City (though far enough to ensorcle [the Savage](/characters/the-savage/), outside the seal, and send us dreams after we had entered the City). We have no evidence yet of any other Lich-controlled activity.
 
 # Notes
-Redyl is not above suspicion - Buddy noted a feeling of ["AN ULTERIOR MOTIVE"](/chapters/walk-the-swine/) emanating, presumably, from either Redyl or the Savage. Given that he's our main source of information on `organization A`, it would be wise to develop alternative lines of investigation.
+Redyl is not above suspicion - [Buddy](/characters/buddy/) noted a feeling of ["AN ULTERIOR MOTIVE"](/chapters/walk-the-swine/) emanating, presumably, from either Redyl or the Savage. Given that he's our main source of information on `organization A`, it would be wise to develop alternative lines of investigation.
 
 The Messenger was recently active in Abireth, though our attempts at intelligence-gathering about him have so far proven fruitless. Surely so influential a figure must have vulnerabilities to investigation - he must somehow communicate with his followers.
 
@@ -63,4 +76,4 @@ The Messenger's Cult seems the most available avenue of investigation - gatherin
 
 Finding and securing Redyl's lost children would help to place Redyl above suspicion, by corroborating his account, as well as providing further eyewitness accounts of `organization A` activity. (In the process, it would suggest that the "ULTERIOR MOTIVE" belonged to the known anti-orc activist The Savage).
 
-The Abireth library or King Slee may have information on "tentacle-faced" individuals, which may provide clues as the membership, methods and motivations of `organization A`.
+The Abireth library or King [Slee](/characters/slee/) may have information on "tentacle-faced" individuals, which may provide clues as the membership, methods and motivations of `organization A`.

--- a/southside/layouts/characters/single.html
+++ b/southside/layouts/characters/single.html
@@ -4,11 +4,16 @@
     <article class="post-container">
         {{ partial "character-header.html" . }}
         {{ partial "page-content.html" . }}
+        {{ $slug := index (split .URL "/") 2 }}
         <h2>Appearances</h2>
         <ul>
-            {{ $appearances := index .Site.Taxonomies.appearances (index (split .URL "/") 2) }}
+            {{ $appearances := index .Site.Taxonomies.appearances $slug }}
             {{ range sort $appearances }}
+            {{ if .Page.Params.chapter }}
             <li><a href="{{ .Page.RelPermalink }}">{{ .Page.Params.chapter }}. {{ .Page.Title }}</a></li>
+            {{ else }}
+            <li><a href="{{ .Page.RelPermalink }}">CF. {{ .Page.Params.Timestamp }}</a></li>
+            {{ end }}
             {{ end }}
         </ul>
 


### PR DESCRIPTION
with this change, the crosslink script and appearances taxonomy work not only between chapters and characters, but also between case files and characters.